### PR TITLE
Counter clockwise selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ There are two different options:
 | showHandlerOutter         |                        true                         | If true will display an extra ring around the handlers.                                                                 |
 | sliderStrokeWidth         |                        12.0                         | The stroke width for the slider (thickness).                                                                            |
 | shouldCountLaps           |                        false                        | If true, onSelectionChange will also return the updated number of laps.                                                 |
+| counterClockwise           |                        false                        | If specified, will draw the slider selection in a counter-clockwise direction.            |
+
 
 ### Use Cases
 

--- a/lib/src/circular_slider_paint.dart
+++ b/lib/src/circular_slider_paint.dart
@@ -29,6 +29,7 @@ class CircularSliderPaint extends StatefulWidget {
   final bool showHandlerOutter;
   final double sliderStrokeWidth;
   final bool shouldCountLaps;
+  final bool counterClockwise;
 
   CircularSliderPaint({
     @required this.mode,
@@ -48,6 +49,7 @@ class CircularSliderPaint extends StatefulWidget {
     @required this.showHandlerOutter,
     @required this.sliderStrokeWidth,
     @required this.shouldCountLaps,
+    this.counterClockwise,
   });
 
   @override
@@ -113,10 +115,10 @@ class _CircularSliderState extends State<CircularSliderPaint> {
         CustomPanGestureRecognizer:
             GestureRecognizerFactoryWithHandlers<CustomPanGestureRecognizer>(
           () => CustomPanGestureRecognizer(
-                onPanDown: _onPanDown,
-                onPanUpdate: _onPanUpdate,
-                onPanEnd: _onPanEnd,
-              ),
+            onPanDown: _onPanDown,
+            onPanUpdate: _onPanUpdate,
+            onPanEnd: _onPanEnd,
+          ),
           (CustomPanGestureRecognizer instance) {},
         ),
       },
@@ -185,6 +187,7 @@ class _CircularSliderState extends State<CircularSliderPaint> {
       showRoundedCapInSelection: widget.showRoundedCapInSelection,
       showHandlerOutter: widget.showHandlerOutter,
       sliderStrokeWidth: widget.sliderStrokeWidth,
+      counterClockwise: widget.counterClockwise,
     );
   }
 

--- a/lib/src/single_circular_slider.dart
+++ b/lib/src/single_circular_slider.dart
@@ -142,7 +142,7 @@ class _SingleCircularSliderState extends State<SingleCircularSlider> {
           showRoundedCapInSelection: widget.showRoundedCapInSelection ?? false,
           showHandlerOutter: widget.showHandlerOutter ?? true,
           shouldCountLaps: widget.shouldCountLaps ?? false,
-          counterClockwise: widget.counterClockwise,
+          counterClockwise: widget.counterClockwise ?? false,
         ));
   }
 }

--- a/lib/src/single_circular_slider.dart
+++ b/lib/src/single_circular_slider.dart
@@ -67,6 +67,9 @@ class SingleCircularSlider extends StatefulWidget {
   /// otherwise, everytime the user completes a full lap, the selection restarts from 0
   final bool shouldCountLaps;
 
+  /// if specified, displays the selection in a counter-clockwise direction
+  final bool counterClockwise;
+
   SingleCircularSlider(
     this.divisions,
     this.position, {
@@ -85,6 +88,7 @@ class SingleCircularSlider extends StatefulWidget {
     this.showHandlerOutter,
     this.sliderStrokeWidth,
     this.shouldCountLaps,
+    this.counterClockwise,
   })  : assert(position >= 0 && position <= divisions,
             'init has to be > 0 and < divisions value'),
         assert(divisions >= 0 && divisions <= 300,
@@ -138,6 +142,7 @@ class _SingleCircularSliderState extends State<SingleCircularSlider> {
           showRoundedCapInSelection: widget.showRoundedCapInSelection ?? false,
           showHandlerOutter: widget.showHandlerOutter ?? true,
           shouldCountLaps: widget.shouldCountLaps ?? false,
+          counterClockwise: widget.counterClockwise,
         ));
   }
 }

--- a/lib/src/slider_painter.dart
+++ b/lib/src/slider_painter.dart
@@ -16,6 +16,7 @@ class SliderPainter extends CustomPainter {
   bool showRoundedCapInSelection;
   bool showHandlerOutter;
   double sliderStrokeWidth;
+  bool counterClockwise;
 
   Offset initHandler;
   Offset endHandler;
@@ -33,6 +34,7 @@ class SliderPainter extends CustomPainter {
     @required this.showRoundedCapInSelection,
     @required this.showHandlerOutter,
     @required this.sliderStrokeWidth,
+    @required this.counterClockwise,
   });
 
   @override
@@ -42,6 +44,9 @@ class SliderPainter extends CustomPainter {
     center = Offset(size.width / 2, size.height / 2);
     radius = min(size.width / 2, size.height / 2) - sliderStrokeWidth;
 
+    if (true == counterClockwise) {
+      sweepAngle = -(2 * pi - sweepAngle);
+    }
     canvas.drawArc(Rect.fromCircle(center: center, radius: radius),
         -pi / 2 + startAngle, sweepAngle, false, progress);
 


### PR DESCRIPTION
This PR add the option to have the selection for `SingleCircularSlider` in a counter-clockwise direction.
Example screenshot with selection in the darker colour below.

Fixes: #18 

![flutter_21](https://user-images.githubusercontent.com/71999/65121843-393d0b80-da33-11e9-84cb-d861acaf0908.png)

